### PR TITLE
Rely on modules

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,26 +25,44 @@ pub fn build(b: *Build) !void {
 
     const lua_src = b.dependency("lua", .{});
 
-    const lib =
-        b.addStaticLibrary(artifactOptions(
-            .{ .shared = false },
-            .{ .target = target, .optimize = optimize },
-        ));
+    const lib = b.addLibrary(.{
+        .name = lib_name,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .link_libc = true,
+            .optimize = optimize,
+            .target = target,
+        }),
+    });
     const shared = if (build_shared)
-        b.addSharedLibrary(artifactOptions(
-            .{ .shared = true },
-            .{ .target = target, .optimize = optimize },
-        ))
+        b.addLibrary(.{
+            .name = lib_name ++ "54",
+            .linkage = .dynamic,
+            .root_module = b.createModule(.{
+                .link_libc = true,
+                .optimize = optimize,
+                .target = target,
+                .strip = if (target.result.os.tag == .windows) true else null,
+            }),
+        })
     else
         null;
-    const exe = b.addExecutable(artifactOptions(.exe, .{
-        .target = target,
-        .optimize = optimize,
-    }));
-    const exec = b.addExecutable(artifactOptions(.exec, .{
-        .target = target,
-        .optimize = optimize,
-    }));
+    const exe = b.addExecutable(.{
+        .name = exe_name,
+        .root_module = b.createModule(.{
+            .link_libc = true,
+            .optimize = optimize,
+            .target = target,
+        }),
+    });
+    const exec = b.addExecutable(.{
+        .name = compiler_name,
+        .root_module = b.createModule(.{
+            .link_libc = true,
+            .optimize = optimize,
+            .target = target,
+        }),
+    });
     if (!target.result.isMinGW()) {
         lib.linkSystemLibrary("m");
         exe.linkSystemLibrary("m");
@@ -169,64 +187,6 @@ pub fn build(b: *Build) !void {
         .install_subdir = "",
     });
     unpack_step.dependOn(&unpack_cmd.step);
-}
-const ArtifactTarget = union(enum) {
-    // True if shared options
-    shared: bool,
-    exe,
-    exec,
-};
-const ArtifactTargetOptions = struct {
-    target: ResolvedTarget,
-    optimize: OptimizeMode,
-};
-fn artifactOptions(comptime options: ArtifactTarget, opts: ArtifactTargetOptions) switch (options) {
-    .exe, .exec => Build.ExecutableOptions,
-    .shared => |shared| if (shared)
-        Build.SharedLibraryOptions
-    else
-        Build.StaticLibraryOptions,
-} {
-    const t = opts.target.result.os.tag;
-    return switch (options) {
-        .shared => |shared| if (shared) blk: {
-            switch (t) {
-                .windows => break :blk .{
-                    .name = lib_name ++ "54",
-                    .target = opts.target,
-                    .optimize = opts.optimize,
-                    .strip = true,
-                },
-                else => break :blk .{
-                    .name = lib_name,
-                    .target = opts.target,
-                    .optimize = opts.optimize,
-                },
-            }
-        } else blk: {
-            switch (t) {
-                else => break :blk .{
-                    .name = lib_name,
-                    .target = opts.target,
-                    .optimize = opts.optimize,
-                },
-            }
-        },
-        .exe => switch (t) {
-            else => .{
-                .name = exe_name,
-                .target = opts.target,
-                .optimize = opts.optimize,
-            },
-        },
-        .exec => switch (t) {
-            else => .{
-                .name = compiler_name,
-                .target = opts.target,
-                .optimize = opts.optimize,
-            },
-        },
-    };
 }
 
 const cflags = [_][]const u8{

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const OptimizeMode = std.builtin.OptimizeMode;
 const version = std.SemanticVersion{
     .major = 5,
     .minor = 4,
-    .patch = 7,
+    .patch = 8,
 };
 const lib_name = "lua";
 const exe_name = lib_name ++ "_exe";

--- a/build.zig
+++ b/build.zig
@@ -8,9 +8,6 @@ const version = std.SemanticVersion{
     .minor = 4,
     .patch = 8,
 };
-const lib_name = "lua";
-const exe_name = lib_name ++ "_exe";
-const compiler_name = "luac";
 
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -25,150 +22,139 @@ pub fn build(b: *Build) !void {
 
     const lua_src = b.dependency("lua", .{});
 
-    const lib = b.addLibrary(.{
-        .name = lib_name,
-        .linkage = .static,
-        .root_module = b.createModule(.{
-            .link_libc = true,
-            .optimize = optimize,
-            .target = target,
-        }),
+    const static = b.addModule("staticlib", .{
+        .link_libc = true,
+        .optimize = optimize,
+        .target = target,
     });
-    const shared = if (build_shared)
-        b.addLibrary(.{
-            .name = lib_name ++ "54",
-            .linkage = .dynamic,
-            .root_module = b.createModule(.{
-                .link_libc = true,
-                .optimize = optimize,
-                .target = target,
-                .strip = if (target.result.os.tag == .windows) true else null,
-            }),
-        })
-    else
-        null;
-    const exe = b.addExecutable(.{
-        .name = exe_name,
-        .root_module = b.createModule(.{
-            .link_libc = true,
-            .optimize = optimize,
-            .target = target,
-        }),
-    });
-    const exec = b.addExecutable(.{
-        .name = compiler_name,
-        .root_module = b.createModule(.{
-            .link_libc = true,
-            .optimize = optimize,
-            .target = target,
-        }),
-    });
-    if (!target.result.isMinGW()) {
-        lib.linkSystemLibrary("m");
-        exe.linkSystemLibrary("m");
-        exec.linkSystemLibrary("m");
-    }
-    const build_targets = [_]?*Build.Step.Compile{
-        lib,
-        exe,
-        exec,
-        shared,
-    };
-    // Common compile flags
-    for (&build_targets) |tr| {
-        if (tr == null)
-            continue;
-        const t = tr.?;
-        t.linkLibC();
-        t.addIncludePath(lua_src.path("src"));
-        switch (target.result.os.tag) {
-            .aix => {
-                t.root_module.addCMacro("LUA_USE_POSIX", "");
-                t.root_module.addCMacro("LUA_USE_DLOPEN", "");
-                t.linkSystemLibrary("dl");
-            },
-            .freebsd, .netbsd, .openbsd => {
-                t.root_module.addCMacro("LUA_USE_LINUX", "");
-                t.root_module.addCMacro("LUA_USE_READLINE", "");
-                t.addIncludePath(.{ .cwd_relative = "/usr/include/edit" });
-                t.linkSystemLibrary("edit");
-            },
-            .ios => {
-                t.root_module.addCMacro("LUA_USE_IOS", "");
-            },
-            .linux => {
-                t.root_module.addCMacro("LUA_USE_LINUX", "");
-                t.linkSystemLibrary("dl");
-                if (use_readline.?) {
-                    t.root_module.addCMacro("LUA_USE_READLINE", "");
-                    t.linkSystemLibrary("readline");
-                }
-            },
-            .macos => {
-                t.root_module.addCMacro("LUA_USE_MACOSX", "");
-                t.root_module.addCMacro("LUA_USE_READLINE", "");
-                t.linkSystemLibrary("readline");
-            },
-            .solaris => {
-                t.root_module.addCMacro("LUA_USE_POSIX", "");
-                t.root_module.addCMacro("LUA_USE_DLOPEN", "");
-                t.root_module.addCMacro("_REENTRANT", "");
-                t.linkSystemLibrary("dl");
-            },
-            else => {},
-        }
-    }
-    if (target.result.isMinGW()) {
-        lib.root_module.addCMacro("LUA_BUILD_AS_DLL", "");
-        exe.root_module.addCMacro("LUA_BUILD_AS_DLL", "");
-    }
-    if (shared) |s| {
-        s.addCSourceFiles(.{
-            .root = lua_src.path("src"),
-            .files = &base_src,
-            .flags = &cflags,
-        });
-
-        s.installHeadersDirectory(
-            lua_src.path("src"),
-            "",
-            .{ .include_extensions = &lua_inc },
-        );
-    }
-
-    lib.addCSourceFiles(.{
+    static.addCSourceFiles(.{
         .root = lua_src.path("src"),
         .files = &base_src,
         .flags = &cflags,
     });
 
-    lib.installHeadersDirectory(
-        lua_src.path("src"),
-        "",
-        .{ .include_extensions = &lua_inc },
-    );
+    const shared = b.addModule("sharedlib", .{
+        .link_libc = true,
+        .optimize = optimize,
+        .target = target,
+        .strip = if (target.result.os.tag == .windows) true else null,
+    });
+    shared.addCSourceFiles(.{
+        .root = lua_src.path("src"),
+        .files = &base_src,
+        .flags = &cflags,
+    });
 
+    const exe = b.addModule("interpreter", .{
+        .link_libc = true,
+        .optimize = optimize,
+        .target = target,
+    });
     exe.addCSourceFile(.{
         .file = lua_src.path("src/lua.c"),
         .flags = &cflags,
     });
 
+    const exec = b.addModule("compiler", .{
+        .link_libc = true,
+        .optimize = optimize,
+        .target = target,
+    });
     exec.addCSourceFile(.{
         .file = lua_src.path("src/luac.c"),
         .flags = &cflags,
     });
 
-    if (shared) |s| {
-        exe.linkLibrary(s);
-        b.installArtifact(s);
-    } else {
-        exe.linkLibrary(lib);
-        b.installArtifact(lib);
+    // Common compile flags
+    for (&[_]*Build.Module{ static, shared, exe, exec }) |mod| {
+        const link = mod != shared;
+
+        mod.addIncludePath(lua_src.path("src"));
+        if (link and !target.result.isMinGW())
+            mod.linkSystemLibrary("m", .{});
+
+        switch (target.result.os.tag) {
+            .aix => {
+                mod.addCMacro("LUA_USE_POSIX", "");
+                mod.addCMacro("LUA_USE_DLOPEN", "");
+                if (link)
+                    mod.linkSystemLibrary("dl", .{});
+            },
+            .freebsd, .netbsd, .openbsd => {
+                mod.addCMacro("LUA_USE_LINUX", "");
+                mod.addCMacro("LUA_USE_READLINE", "");
+                mod.addIncludePath(.{ .cwd_relative = "/usr/include/edit" });
+                if (link)
+                    mod.linkSystemLibrary("edit", .{});
+            },
+            .ios => {
+                mod.addCMacro("LUA_USE_IOS", "");
+            },
+            .linux => {
+                mod.addCMacro("LUA_USE_LINUX", "");
+                if (link)
+                    mod.linkSystemLibrary("dl", .{});
+                if (use_readline.?) {
+                    mod.addCMacro("LUA_USE_READLINE", "");
+                    if (link)
+                        mod.linkSystemLibrary("readline", .{});
+                }
+            },
+            .macos => {
+                mod.addCMacro("LUA_USE_MACOSX", "");
+                mod.addCMacro("LUA_USE_READLINE", "");
+                if (link)
+                    mod.linkSystemLibrary("readline", .{});
+            },
+            .solaris => {
+                mod.addCMacro("LUA_USE_POSIX", "");
+                mod.addCMacro("LUA_USE_DLOPEN", "");
+                mod.addCMacro("_REENTRANT", "");
+                if (link)
+                    mod.linkSystemLibrary("dl", .{});
+            },
+            else => {},
+        }
+    }
+    if (target.result.isMinGW()) {
+        static.addCMacro("LUA_BUILD_AS_DLL", "");
+        exe.addCMacro("LUA_BUILD_AS_DLL", "");
     }
 
-    b.installArtifact(exe);
-    exec.linkLibrary(lib);
-    b.installArtifact(exec);
+    const sharedlib = b.addLibrary(.{
+        .name = "lua" ++ &[_]u8{
+            '0' + version.major, '0' + version.minor,
+        },
+        .root_module = shared,
+        .version = version,
+        .linkage = .dynamic,
+    });
+    b.installArtifact(sharedlib);
+
+    const staticlib =
+        b.addLibrary(.{
+            .name = "lua",
+            .root_module = static,
+            .version = version,
+            .linkage = .static,
+        });
+    b.installArtifact(staticlib);
+
+    exe.linkLibrary(if (build_shared) sharedlib else staticlib);
+    const lua_exe = b.addExecutable(.{
+        .name = "lua_exe",
+        .version = version,
+        .root_module = exe,
+    });
+    b.installArtifact(lua_exe);
+
+    exec.linkLibrary(staticlib);
+    const luac_exe = b.addExecutable(.{
+        .name = "luac",
+        .version = version,
+        .root_module = exe,
+    });
+    b.installArtifact(luac_exe);
 
     b.installDirectory(.{
         .source_dir = lua_src.path("doc"),
@@ -178,7 +164,8 @@ pub fn build(b: *Build) !void {
     });
 
     const run_step = b.step("run", "run lua interpreter");
-    const run_cmd = b.addRunArtifact(exe);
+    const run_cmd = b.addRunArtifact(lua_exe);
+    if (b.args) |args| run_cmd.addArgs(args);
     run_step.dependOn(&run_cmd.step);
     const unpack_step = b.step("unpack", "unpack source");
     const unpack_cmd = b.addInstallDirectory(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,14 +1,14 @@
 .{
     .name = .lua,
-    .version = "5.4.7",
+    .version = "5.4.8",
     .fingerprint = 0xd671372bcadcaace,
 
     .minimum_zig_version = "0.15.0",
 
     .dependencies = .{
         .lua = .{
-            .url = "https://www.lua.org/ftp/lua-5.4.7.tar.gz",
-            .hash = "N-V-__8AAIMvFABt-Qcpk24RD10ldEN743D8Q2e19Er8x3dJ",
+            .url = "https://www.lua.org/ftp/lua-5.4.8.tar.gz",
+            .hash = "N-V-__8AAKEzFAAA695b9LXBhUSVK5MAV_VKSm1mEj3Acbze",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "5.4.7",
     .fingerprint = 0xd671372bcadcaace,
 
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
 
     .dependencies = .{
         .lua = .{


### PR DESCRIPTION
blocked on #2. the 3rd commit is the proper diff until #2 lands.

this commit primarily accomplishes 3 things:
1. instead of only exporting the artifacts of the compiled lua, the available artifacts are also available as modules. This allows more possibilities when compiling lua, such as configuring additional C macros (for configuration) and linking additional libraries into the CLI.
   - The modules are available as `staticlib`, `sharedlib`, `interpreter`, and `compiler`
   - Note that `sharedlib` is always available, regardless of whether `-Dshared` is passed
2. instead of configuring external library linkage through the `Compile` step, links are added directly to the module, avoiding some future deprecations.
3. avoid linking external libraries to the shared library. this is in accordance with the documentation from the lua distribution